### PR TITLE
Fix GitHub Pages deployment issues

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,9 +32,6 @@ jobs:
           NEXT_PUBLIC_FIREBASE_APP_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_APP_ID }}
           NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID }}
 
-      - name: Export static files
-        run: npm run export
-
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,1 @@
+# DataHammer Documentation

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>DataHammer Documentation</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        h1 {
+            color: #333;
+        }
+        p {
+            color: #666;
+        }
+    </style>
+</head>
+<body>
+    <h1>DataHammer Documentation</h1>
+    <p>This is the documentation site for DataHammer. The main application is deployed at <a href="https://bainmchale.github.io/DataHammer/">https://bainmchale.github.io/DataHammer/</a>.</p>
+    <p>Please refer to the <a href="https://github.com/BainMcHale/DataHammer">GitHub repository</a> for more information.</p>
+</body>
+</html>

--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,7 @@ const nextConfig = {
   },
   // Add basePath for GitHub Pages deployment
   // Comment this out for local development
-  // basePath: '/your-repo-name',
+  basePath: '/DataHammer',
 };
 
 module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
-    "export": "next export"
+    "lint": "next lint"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.8.2",


### PR DESCRIPTION
## Description
This PR fixes the GitHub Pages deployment issues by:

1. Removing the unnecessary `next export` step from the GitHub Actions workflow
2. Updating the Next.js configuration to use the correct basePath for GitHub Pages
3. Removing the deprecated `export` script from package.json
4. Adding a docs directory with basic content for GitHub Pages

## Changes Made
- Updated `.github/workflows/deploy.yml` to remove the export step
- Updated `next.config.js` to set the correct basePath
- Removed the `export` script from `package.json`
- Added a `docs` directory with basic content

## Testing
These changes should fix the GitHub Pages deployment issues. Once merged, the GitHub Actions workflow should complete successfully.