### PR TITLE
Fix ESLint errors in FileUpload component

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -6,7 +6,6 @@ import {
   Box,
   Button,
   Center,
-  Flex,
   Heading,
   Icon,
   Text,
@@ -18,7 +17,7 @@ import axios from 'axios'
 export default function FileUpload() {
   const [file, setFile] = useState<File | null>(null)
   const [isLoading, setIsLoading] = useState(false)
-  const [analysisResult, setAnalysisResult] = useState<any>(null)
+  const [analysisResult, setAnalysisResult] = useState<Record<string, unknown> | null>(null)
   const toast = useToast()
 
   const onDrop = useCallback((acceptedFiles: File[]) => {


### PR DESCRIPTION
This PR fixes the ESLint errors in the FileUpload component that were causing the GitHub Pages deployment to fail. Specifically:

1. Removed unused `Flex` import
2. Replaced `any` type with `Record<string, unknown>` for better type safety

These changes allow the build to complete successfully and should fix the GitHub Pages deployment.